### PR TITLE
Reduce the memory use by the UART driver.

### DIFF
--- a/examples/sparks_meet_in_middle.toit
+++ b/examples/sparks_meet_in_middle.toit
@@ -46,7 +46,7 @@ main:
       set_both_ends r it-8 1
       set_both_ends r it-9 0
       neopixels.output r g b w
-      sleep --ms=1
+      sleep --ms=2
 
     // Explosion on the whole strip in white, fading away to black.
     for i := 255; i > -10; i -= 10:
@@ -55,7 +55,7 @@ main:
       bytemap_zap b (max i 0)
       bytemap_zap w (max i 0)
       neopixels.output r g b w
-      sleep --ms=1
+      sleep --ms=2
 
 set array i v:
   if 0 <= i < array.size: array[i] = v

--- a/src/pixel_strip.toit
+++ b/src/pixel_strip.toit
@@ -38,6 +38,11 @@ abstract class PixelStrip:
     strip.  The byte arrays should have the same size as $pixels.
   Data is copied out of the byte arrays, so you can reuse them for the next
     frame.
+  The pixel hardware uses a pause in the transmission to detect the 
+    start of the next frame of image data.  Therefore you should leave
+    a few milliseconds before calling this method again.  If your program
+    generates the next frame too fast you may have to add sleep--ms=2 after
+    each call to this method.
   */
   output red/ByteArray green/ByteArray blue/ByteArray white/ByteArray?=null -> none:
     if white == null and bytes_per_pixel_ >= 4: throw "INVALID_ARGUMENT"

--- a/src/uart.toit
+++ b/src/uart.toit
@@ -75,7 +75,7 @@ abstract class UartEncodingPixelStrip_ extends PixelStrip:
     0b00_110_10,   // 0b101
     0b10_100_10,   // 0b110
     0b00_100_10,   // 0b111
-    ]
+  ]
 
   // Blit requires a 256-entry table although only the first 8 entries will be
   // used.
@@ -104,7 +104,7 @@ class UartPixelStrip extends UartEncodingPixelStrip_:
     // To use a UART port for WS2812B protocol we set the speed to 2.5 Mbaud,
     // which enables us to control the TX line with a 400ns granularity.
     // Serial lines are normally high when idle, but the protocol requires
-    // low when idle, so we invert the signal.  This also means the start
+    // low when idle, so we invert the signal by default.  This also means the start
     // bit, normally low, is now high.
     tx := gpio.Pin.out pin
     port_ = uart.Port
@@ -119,6 +119,6 @@ class UartPixelStrip extends UartEncodingPixelStrip_:
   close->none:
     port_.close
 
-  /// See superclass.
+  /// See $super.
   output_interleaved interleaved_data/ByteArray -> none:
     output_interleaved_ interleaved_data: port_.write it

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,0 +1,5 @@
+prefixes:
+  pixel_strip: ..
+packages:
+  ..:
+    path: ..

--- a/tests/test-uart-encoding.toit
+++ b/tests/test-uart-encoding.toit
@@ -1,0 +1,98 @@
+// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import pixel_strip show *
+import pixel_strip.uart show *
+
+// Test that the Uart code correctly encodes binary data in
+// the high-low pattern that the pixel protocol requires.
+
+class UartTestPixelStrip extends UartEncodingPixelStrip_:
+
+  constructor pixels/int --bytes_per_pixel/int:
+    super pixels --bytes_per_pixel=bytes_per_pixel
+
+  output_interleaved interleaved_data/ByteArray -> none:
+    // We only implemented this method to avoid the abstract class error, it's not used for testing.
+    throw "UNREACHABLE"
+
+expect_uart_equals interleaved/ByteArray array/ByteArray:
+  encoding := create_high_low_encoding interleaved
+  // 3 bits encoded in each byte.
+  bits_encoded := array.size * 3
+
+  // We expect the total number of bits encoded to be a whole byte.
+  expect bits_encoded % 8 == 0
+
+  // We expect each bit to be encoded by three characters (HLL or HHL).
+  expect_equals encoding.size / 3 bits_encoded
+
+  for i := 0; i < bits_encoded; i += 3:
+    byte := array[i / 3]
+    first_bits :=  (byte & 0b00_000_11) >> 0  // Uart transmits low bits first.
+    middle_bits := (byte & 0b00_111_00) >> 2
+    last_bits :=   (byte & 0b11_000_00) >> 5  // Uart transmits high bits last.
+    first_s :=  encoding[i * 3 + 0..i * 3 + 3]
+    middle_s := encoding[i * 3 + 3..i * 3 + 6]
+    last_s :=   encoding[i * 3 + 6..i * 3 + 9]
+    if first_s == "HLL":
+      expect_equals 0b11 first_bits     // Start bit is H after inversion, then we have LL (11 before inversion).
+    else if first_s == "HHL":
+      expect_equals 0b10 first_bits     // Start bit is H after inversion, then we have HL (01 before inversion, little endian order).
+    else:
+      throw "Malformed expectation: $first_s"
+    if middle_s == "HLL":
+      expect_equals 0b110 middle_bits   // Little endian order, HLL after inversion.
+    else if middle_s == "HHL":
+      expect_equals 0b100 middle_bits   // Little endian order, HHL after inversion.
+    else:
+      throw "Malformed expectation: $middle_s"
+    if last_s == "HLL":
+      expect_equals 0b10 last_bits      // HL after inversion, little endian order, then the stop bit is L after inversion.
+    else if last_s == "HHL":
+      expect_equals 0b00 last_bits      // HH after inversion, then the stop bit is L after inversion.
+    else:
+      throw "Malformed expectation: $last_s"
+
+create_high_low_encoding ba/ByteArray:
+  result := ""
+  ba.do: | byte |
+    for i := 7; i >= 0; i--:  // Bits in pixel protocol must be sent big-endian first.
+      bit := (byte >> i) & 1
+      result += ["HLL", "HHL"][bit]  // Encode 0 as High-Low-Low and 1 and High-High-Low.
+  return result
+
+main:
+  one_pix := UartTestPixelStrip 1 --bytes_per_pixel=3
+
+  three_zeros := #[0, 0, 0]
+  one_pix.output_interleaved_ three_zeros:
+    expect_uart_equals
+      three_zeros
+      it
+    it.size
+
+  all_ones := #[0xff, 0xff, 0xff]
+  one_pix.output_interleaved_ all_ones:
+    expect_uart_equals
+      all_ones
+      it
+    it.size
+
+  random_bytes := #[41, 103, 243]
+  one_pix.output_interleaved_ random_bytes:
+    expect_uart_equals
+      random_bytes
+      it
+    it.size
+
+  many_pix := UartTestPixelStrip 255 / 3 --bytes_per_pixel=3
+
+  long_sequence := ByteArray 255: it
+  many_pix.output_interleaved_ long_sequence:
+    expect_uart_equals
+      long_sequence
+      it
+    it.size


### PR DESCRIPTION
The Uart driver was using 9 256-byte tables to encode the
pixel data for the UART.  With this change it only uses one
table.  The cost is that we have 10 calls to `blit` instead
of 9.  Also adds some testing of the encoding algorithm.